### PR TITLE
Observation info

### DIFF
--- a/schemas/SpectrumXds.json
+++ b/schemas/SpectrumXds.json
@@ -3169,63 +3169,70 @@
           {
             "$class": "AttrSchemaRef",
             "type": "str",
-            "name": "project",
-            "docstring": "Project Code/Project_UID"
-          },
-          {
-            "$class": "AttrSchemaRef",
-            "type": "str",
             "name": "release_date",
             "docstring": "Project release date. This is the date on which the data may become\npublic. Format: YYYY-MM-DDTHH:mm:ss.SSS (ISO 8601)"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
+            "name": "project_UID",
+            "docstring": "Project UID/code. When populated from an ASDM, the entityId string of the projectUID\nattribute of the ExecBlock table."
+          },
+          {
+            "$class": "AttrSchemaRef",
+            "type": "str",
             "optional": true,
             "name": "execution_block_id",
-            "docstring": "ASDM: Indicates the position of the execution block in the project\n(sequential numbering starting at 1).  "
+            "docstring": "From ASDM: identifies a unique row in ExecBlock Table. Intended ot be populated with\nthe value of the execBlockId attribute of the ExecBlock table"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "int",
             "optional": true,
             "name": "execution_block_number",
-            "docstring": "ASDM: Indicates the position of the execution block in the project\n(sequential numbering starting at 1)."
+            "docstring": "From ASDM: Indicates the position of the execution block in the project (sequential\nnumbering starting at 1). Intended to be populated with the execBlockNum attribute of the\nExecBlock table"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "execution_block_UID",
-            "docstring": "ASDM: The archive’s UID of the execution block."
+            "docstring": "From ASDM: The archive’s UID of the execution block. Intended to be populated with the\nentityId string of the execBlockUID attribute of the ExecBlock table."
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
-            "name": "session_reference",
-            "docstring": "ASDM: The observing session reference."
+            "name": "session_reference_UID",
+            "docstring": "From ASDM: The observing session reference. Intended to be populated with the entityId\nstring of the sessionReference attribute of the ExecBlock table"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "observing_script",
-            "docstring": "ASDM: The text of the observation script."
+            "docstring": "From ASDM: The text of the observation script. Intended to be populated with the\nobservingScript string value of the observingScript attribute of the ExecBlock table."
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "observing_script_UID",
-            "docstring": "ASDM: A reference to the Entity which contains the observing script."
+            "docstring": "From ASDM: A reference to the Entity which contains the observing script. Intended to be\npopulated with the entityId string of the observingScriptUID attribute of the ExecBlock table."
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "observing_log",
-            "docstring": "ASDM: Logs of the observation during this execu- tion block."
+            "docstring": "The observing log, as supplied by the telescope or instrument. Or also from ASDM: Logs of\nthe observation during this execution block. When taken from an ASDM, it is intended to be\npopulated with the values of the observingLog attribute of the ExecBlock table."
+          },
+          {
+            "$class": "AttrSchemaRef",
+            "type": "str",
+            "optional": true,
+            "name": "scheduling_block_UID",
+            "docstring": "From ASDM: The scheduling block archive’s UID. Intended to be populated with the entityId\nstring of the sbSummaryUID attribute of the SBSummary table. "
           },
           {
             "$class": "AttrSchemaRef",
@@ -3234,7 +3241,7 @@
             "docstring": "An intent string identifies one intention of the scan, such as to calibrate or observe a\ntarget. See :ref:`scan intents` for possible intent/subintent values. When converting from MSv2,\nthe list of intents is derived from the OBS_MODE column of MSv2 state table (every comma\nseparated value is taken as an intent).\nA common convention used in the MSv2 OBS_MODE column is to specify multiple intents separated\nby commas, each of them giving a main intent and a subintent separated by a '#' character. This\nis represented in this attribute as a list of \"intent#subintent\" strings. These are a few\nexample lists:\n[\"CALIBRATE_DELAY#ON_SOURCE\" , \"CALIBRATE_PHASE#ON_SOURCE\", \"CALIBRATE_WVR#ON_SOURCE\"],\n[\"CALIBRATE_FLUX#ON_SOURCE\" , \"CALIBRATE_WVR#ON_SOURCE\"],\n[\"CALIBRATE_POINTING#ON_SOURCE\", \"CALIBRATE_WVR#ON_SOURCE\", \"CALIBRATE_DELAY#ON_SOURCE\"],\n[\"CALIBRATE_ATMOSPHERE#AMBIENT\", \"CALIBRATE_WVR#AMBIENT\"],\n[\"CALIBRATE_FOCUS#ON_SOURCE\" , \"CALIBRATE_WVR#ON_SOURCE\"],\n[\"OBSERVE_TARGET#ON_SOURCE\"], or [\"OBSERVE_TARGE#UNSPECIFIED\"].\nThe list of possible intent and subintent names (see :ref:`scan intents`) is derived from the\nrespective ASDM enumerations."
           }
         ],
-        "class_docstring": "ObservationInfoDict(observer: 'list[str]', project: 'str', release_date: 'str', execution_block_id: 'Optional[str]', execution_block_number: 'Optional[int]', execution_block_UID: 'Optional[str]', session_reference: 'Optional[str]', observing_script: 'Optional[str]', observing_script_UID: 'Optional[str]', observing_log: 'Optional[str]', intents: 'list[str]')"
+        "class_docstring": "ObservationInfoDict(observer: 'list[str]', release_date: 'str', project_UID: 'str', execution_block_id: 'Optional[str]', execution_block_number: 'Optional[int]', execution_block_UID: 'Optional[str]', session_reference_UID: 'Optional[str]', observing_script: 'Optional[str]', observing_script_UID: 'Optional[str]', observing_log: 'Optional[str]', scheduling_block_UID: 'Optional[str]', intents: 'list[str]')"
       },
       "name": "observation_info",
       "docstring": null

--- a/schemas/VisibilityXds.json
+++ b/schemas/VisibilityXds.json
@@ -3503,63 +3503,70 @@
           {
             "$class": "AttrSchemaRef",
             "type": "str",
-            "name": "project",
-            "docstring": "Project Code/Project_UID"
-          },
-          {
-            "$class": "AttrSchemaRef",
-            "type": "str",
             "name": "release_date",
             "docstring": "Project release date. This is the date on which the data may become\npublic. Format: YYYY-MM-DDTHH:mm:ss.SSS (ISO 8601)"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
+            "name": "project_UID",
+            "docstring": "Project UID/code. When populated from an ASDM, the entityId string of the projectUID\nattribute of the ExecBlock table."
+          },
+          {
+            "$class": "AttrSchemaRef",
+            "type": "str",
             "optional": true,
             "name": "execution_block_id",
-            "docstring": "ASDM: Indicates the position of the execution block in the project\n(sequential numbering starting at 1).  "
+            "docstring": "From ASDM: identifies a unique row in ExecBlock Table. Intended ot be populated with\nthe value of the execBlockId attribute of the ExecBlock table"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "int",
             "optional": true,
             "name": "execution_block_number",
-            "docstring": "ASDM: Indicates the position of the execution block in the project\n(sequential numbering starting at 1)."
+            "docstring": "From ASDM: Indicates the position of the execution block in the project (sequential\nnumbering starting at 1). Intended to be populated with the execBlockNum attribute of the\nExecBlock table"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "execution_block_UID",
-            "docstring": "ASDM: The archive’s UID of the execution block."
+            "docstring": "From ASDM: The archive’s UID of the execution block. Intended to be populated with the\nentityId string of the execBlockUID attribute of the ExecBlock table."
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
-            "name": "session_reference",
-            "docstring": "ASDM: The observing session reference."
+            "name": "session_reference_UID",
+            "docstring": "From ASDM: The observing session reference. Intended to be populated with the entityId\nstring of the sessionReference attribute of the ExecBlock table"
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "observing_script",
-            "docstring": "ASDM: The text of the observation script."
+            "docstring": "From ASDM: The text of the observation script. Intended to be populated with the\nobservingScript string value of the observingScript attribute of the ExecBlock table."
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "observing_script_UID",
-            "docstring": "ASDM: A reference to the Entity which contains the observing script."
+            "docstring": "From ASDM: A reference to the Entity which contains the observing script. Intended to be\npopulated with the entityId string of the observingScriptUID attribute of the ExecBlock table."
           },
           {
             "$class": "AttrSchemaRef",
             "type": "str",
             "optional": true,
             "name": "observing_log",
-            "docstring": "ASDM: Logs of the observation during this execu- tion block."
+            "docstring": "The observing log, as supplied by the telescope or instrument. Or also from ASDM: Logs of\nthe observation during this execution block. When taken from an ASDM, it is intended to be\npopulated with the values of the observingLog attribute of the ExecBlock table."
+          },
+          {
+            "$class": "AttrSchemaRef",
+            "type": "str",
+            "optional": true,
+            "name": "scheduling_block_UID",
+            "docstring": "From ASDM: The scheduling block archive’s UID. Intended to be populated with the entityId\nstring of the sbSummaryUID attribute of the SBSummary table. "
           },
           {
             "$class": "AttrSchemaRef",
@@ -3568,7 +3575,7 @@
             "docstring": "An intent string identifies one intention of the scan, such as to calibrate or observe a\ntarget. See :ref:`scan intents` for possible intent/subintent values. When converting from MSv2,\nthe list of intents is derived from the OBS_MODE column of MSv2 state table (every comma\nseparated value is taken as an intent).\nA common convention used in the MSv2 OBS_MODE column is to specify multiple intents separated\nby commas, each of them giving a main intent and a subintent separated by a '#' character. This\nis represented in this attribute as a list of \"intent#subintent\" strings. These are a few\nexample lists:\n[\"CALIBRATE_DELAY#ON_SOURCE\" , \"CALIBRATE_PHASE#ON_SOURCE\", \"CALIBRATE_WVR#ON_SOURCE\"],\n[\"CALIBRATE_FLUX#ON_SOURCE\" , \"CALIBRATE_WVR#ON_SOURCE\"],\n[\"CALIBRATE_POINTING#ON_SOURCE\", \"CALIBRATE_WVR#ON_SOURCE\", \"CALIBRATE_DELAY#ON_SOURCE\"],\n[\"CALIBRATE_ATMOSPHERE#AMBIENT\", \"CALIBRATE_WVR#AMBIENT\"],\n[\"CALIBRATE_FOCUS#ON_SOURCE\" , \"CALIBRATE_WVR#ON_SOURCE\"],\n[\"OBSERVE_TARGET#ON_SOURCE\"], or [\"OBSERVE_TARGE#UNSPECIFIED\"].\nThe list of possible intent and subintent names (see :ref:`scan intents`) is derived from the\nrespective ASDM enumerations."
           }
         ],
-        "class_docstring": "ObservationInfoDict(observer: 'list[str]', project: 'str', release_date: 'str', execution_block_id: 'Optional[str]', execution_block_number: 'Optional[int]', execution_block_UID: 'Optional[str]', session_reference: 'Optional[str]', observing_script: 'Optional[str]', observing_script_UID: 'Optional[str]', observing_log: 'Optional[str]', intents: 'list[str]')"
+        "class_docstring": "ObservationInfoDict(observer: 'list[str]', release_date: 'str', project_UID: 'str', execution_block_id: 'Optional[str]', execution_block_number: 'Optional[int]', execution_block_UID: 'Optional[str]', session_reference_UID: 'Optional[str]', observing_script: 'Optional[str]', observing_script_UID: 'Optional[str]', observing_log: 'Optional[str]', scheduling_block_UID: 'Optional[str]', intents: 'list[str]')"
       },
       "name": "observation_info",
       "docstring": null

--- a/src/xradio/measurement_set/_utils/_msv2/msv4_info_dicts.py
+++ b/src/xradio/measurement_set/_utils/_msv2/msv4_info_dicts.py
@@ -21,7 +21,7 @@ def create_info_dicts(
     field_and_source_xds: xr.Dataset,
     partition_info_misc_fields: dict,
     tb_tool: tables.table,
-) -> dict:
+) -> dict[str, dict]:
     """
     For an MSv4, produces several info dicts (partition_info, processor_info,
     observation_info). The info dicts are returned in a dictionary that
@@ -88,7 +88,9 @@ def create_info_dicts(
     return info_dicts
 
 
-def create_observation_info(in_file: str, observation_id: int):
+def create_observation_info(
+    in_file: str, observation_id: int
+) -> dict[str, list[str] | str]:
     """
     Makes a dict with the observation info extracted from the PROCESSOR subtable.
     When available, it also takes metadata from the ASDM tables (imported 'asis')
@@ -158,7 +160,7 @@ def create_observation_info(in_file: str, observation_id: int):
 
 def try_optional_asdm_asis_table_info(
     in_file: str, asdm_table_name: str, optional_fields: dict[str, str]
-) -> dict:
+) -> dict[str, str]:
     """
     Tries to find an optional ASDM_* subtable (ASDM_EXECBLOCK, ASDM_SBSUMMARY, etc.),
     and if available, gets the optional fields requested into a metadata dict. That
@@ -200,7 +202,7 @@ def try_optional_asdm_asis_table_info(
 
 def extract_optional_fields_asdm_asis_table(
     asdm_asis_xds: xr.Dataset, optional_fields: dict[str, str]
-) -> dict:
+) -> dict[str, str]:
     """
     Get the (optional) fields of the observation_info that come from "asis" ASDM
     tables like the ASDM_EXECBLOCK and ASDM_SBSUMMARY subtables.
@@ -235,7 +237,7 @@ def extract_optional_fields_asdm_asis_table(
 
 def try_find_uids_from_observation_schedule(
     generic_observation_xds: xr.Dataset, observation_info: dict
-) -> dict:
+) -> dict[str, str]:
     """
     This function tries to parse the execution_block_UID and scheduling_block_UID
     from the SCHEDULE column of the OBSERVATION subtable. If found, and they
@@ -280,7 +282,7 @@ def try_find_uids_from_observation_schedule(
     return out_info
 
 
-def replace_entity_ids(observation_info: dict) -> dict:
+def replace_entity_ids(observation_info: dict) -> dict[str, list[str] | str]:
     """
     For several fields of the input dictionary, which are known to be of "UID" type,
     replace their lengthy XML string with the UID value contained in it. For example, from
@@ -349,7 +351,7 @@ def search_entity_id(entity_ref_xml: str) -> str:
     return entity_id
 
 
-def create_processor_info(in_file: str, processor_id: int):
+def create_processor_info(in_file: str, processor_id: int) -> dict[str, str]:
     """
     Makes a dict with the processor info extracted from the PROCESSOR subtable.
 

--- a/src/xradio/measurement_set/schema.py
+++ b/src/xradio/measurement_set/schema.py
@@ -9,7 +9,7 @@ from xradio.schema.bases import (
 from xradio.schema.typing import Attr, Coord, Coordof, Data, Dataof
 import numpy
 
-MSV4_SCHEMA_VERSION = "4.0.-9987"
+MSV4_SCHEMA_VERSION = "4.0.-9986"
 
 # Dimensions
 Time = Literal["time"]
@@ -1362,27 +1362,38 @@ class VisibilityArray:
 class ObservationInfoDict:
     observer: list[str]
     """List of observer names."""
-    project: str
-    """Project Code/Project_UID"""
     release_date: str
     """Project release date. This is the date on which the data may become
     public. Format: YYYY-MM-DDTHH:mm:ss.SSS (ISO 8601)"""
+    project_UID: str
+    """Project UID/code. When populated from an ASDM, the entityId string of the projectUID
+    attribute of the ExecBlock table."""
     execution_block_id: Optional[str]
-    """ ASDM: Indicates the position of the execution block in the project
-    (sequential numbering starting at 1).  """
+    """From ASDM: identifies a unique row in ExecBlock Table. Intended ot be populated with
+    the value of the execBlockId attribute of the ExecBlock table"""
     execution_block_number: Optional[int]
-    """ASDM: Indicates the position of the execution block in the project
-    (sequential numbering starting at 1)."""
+    """From ASDM: Indicates the position of the execution block in the project (sequential
+    numbering starting at 1). Intended to be populated with the execBlockNum attribute of the
+    ExecBlock table"""
     execution_block_UID: Optional[str]
-    """ASDM: The archive’s UID of the execution block."""
-    session_reference: Optional[str]
-    """ASDM: The observing session reference."""
+    """From ASDM: The archive’s UID of the execution block. Intended to be populated with the
+    entityId string of the execBlockUID attribute of the ExecBlock table."""
+    session_reference_UID: Optional[str]
+    """From ASDM: The observing session reference. Intended to be populated with the entityId
+    string of the sessionReference attribute of the ExecBlock table"""
     observing_script: Optional[str]
-    """ASDM: The text of the observation script."""
+    """From ASDM: The text of the observation script. Intended to be populated with the
+    observingScript string value of the observingScript attribute of the ExecBlock table."""
     observing_script_UID: Optional[str]
-    """ASDM: A reference to the Entity which contains the observing script."""
+    """From ASDM: A reference to the Entity which contains the observing script. Intended to be
+    populated with the entityId string of the observingScriptUID attribute of the ExecBlock table."""
     observing_log: Optional[str]
-    """ASDM: Logs of the observation during this execu- tion block."""
+    """The observing log, as supplied by the telescope or instrument. Or also from ASDM: Logs of
+    the observation during this execution block. When taken from an ASDM, it is intended to be
+    populated with the values of the observingLog attribute of the ExecBlock table."""
+    scheduling_block_UID: Optional[str]
+    """From ASDM: The scheduling block archive’s UID. Intended to be populated with the entityId
+    string of the sbSummaryUID attribute of the SBSummary table. """
     intents: list[str]
     """ An intent string identifies one intention of the scan, such as to calibrate or observe a
     target. See :ref:`scan intents` for possible intent/subintent values. When converting from MSv2,

--- a/tests/unit/measurement_set/ms_test_utils/check_msv4_matches_msv2_description.py
+++ b/tests/unit/measurement_set/ms_test_utils/check_msv4_matches_msv2_description.py
@@ -95,10 +95,24 @@ def check_msv4_matches_descr(msv4_xdt, msv2_descr):
         assert processor_info["type"]
         assert processor_info["sub_type"]
 
+    observation_info = msv4_xdt.ds.attrs["observation_info"]
     if msv2_descr["params"]["opt_tables"] and not msv2_descr["params"]["misbehave"]:
-        assert "execution_block_UID" in msv4_xdt.ds.attrs["observation_info"]
+        assert "session_reference_UID" in observation_info
+        assert "observing_script" in observation_info
     else:
-        assert "execution_block_UID" not in msv4_xdt.ds.attrs["observation_info"]
+        assert "session_reference_UID" not in observation_info
+        assert "observing_script" not in observation_info
+
+    if (
+        msv2_descr["params"]["opt_tables"]
+        and not msv2_descr["params"]["misbehave"]
+        or "OBSERVATION" in msv2_descr
+    ):
+        assert "execution_block_UID" in observation_info
+        assert "scheduling_block_UID" in observation_info
+    else:
+        assert "execution_block_UID" not in observation_info
+        assert "scheduling_block_UID" not in observation_info
 
 
 def check_processing_set_matches_msv2_descr(

--- a/tests/unit/measurement_set/test_processing_set_xdt.py
+++ b/tests/unit/measurement_set/test_processing_set_xdt.py
@@ -105,17 +105,23 @@ class TestProcessingSetXdtWithData:
         summary = ps_xdt.xr_ps.summary()
         print(summary)
 
+        summary_ordered = ps_xdt.xr_ps.summary(first_columns=["spw_name", "scan_name"])
+        print(summary_ordered)
+
         # Verify it returns a pandas DataFrame
         assert isinstance(summary, pd.DataFrame)
+        assert isinstance(summary_ordered, pd.DataFrame)
 
         # Verify the DataFrame is not empty
         assert not summary.empty
+        assert not summary_ordered.empty
 
         # Verify expected columns are present
         expected_columns = [
             "name",
             "intents",
             "shape",
+            "execution_block_UID",
             "polarization",
             "scan_name",
             "spw_name",
@@ -124,11 +130,19 @@ class TestProcessingSetXdtWithData:
             "source_name",
             "line_name",
             "field_coords",
+            "session_reference_UID",
+            "scheduling_block_UID",
+            "project_UID",
             "start_frequency",
             "end_frequency",
         ]
         for col in expected_columns:
             assert col in summary.columns
+            assert col in summary_ordered.columns
+
+        # 4 partiions, expected_columns
+        assert summary.shape == (4, len(expected_columns))
+        assert summary.shape == summary_ordered.shape
 
     @pytest.mark.parametrize(
         "convert_measurement_set_to_processing_set",


### PR DESCRIPTION
Test PR for 485.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Processing summary now supports custom column ordering via a first_columns parameter.
  - Summary output includes new columns: execution_block_UID, session_reference_UID, scheduling_block_UID, and project_UID.

- Refactor
  - observation_info schema updated: project renamed to project_UID; session_reference renamed to session_reference_UID; added scheduling_block_UID and observing_script_UID.

- Documentation
  - Field descriptions updated to clarify ASDM-derived sources and mappings.

- Tests
  - Expanded tests cover new summary column ordering and the presence of new observation_info fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->